### PR TITLE
Add classify method in Brain class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,25 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8"
+        "nunomaduro/collision": "^7.8",
+        "orchestra/testbench": "^8.8",
+        "pestphp/pest": "^2.20",
+        "pestphp/pest-plugin-arch": "^2.0",
+        "pestphp/pest-plugin-laravel": "^2.0"
     },
     "autoload": {
         "psr-4": {
             "HelgeSverre\\Brain\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "HelgeSverre\\Brain\\Tests\\": "tests/"
+        }
+    },
     "scripts": {
-        "format": "vendor/bin/pint"
+        "format": "vendor/bin/pint",
+        "test": "vendor/bin/pest"
     },
     "config": {
         "sort-packages": true,

--- a/src/Brain.php
+++ b/src/Brain.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use OpenAI\Laravel\Facades\OpenAI;
 use OpenAI\Responses\Chat\CreateResponse;
-use StringBackedEnum;
 use Throwable;
 
 class Brain
@@ -102,12 +101,12 @@ class Brain
         }
     }
 
-    public function classify(string $input, array|StringBackedEnum $classes, ?int $max = null, bool $fast = true): null|string|StringBackedEnum
+    public function classify(string $input, $classes, ?int $max = null, bool $fast = true)
     {
         if (is_array($classes)) {
             $values = $classes;
             $isEnum = false;
-        } elseif ($classes instanceof StringBackedEnum) {
+        } elseif (enum_exists($classes)) {
             $values = array_column($classes::cases(), 'value');
             $isEnum = true;
         } else {

--- a/tests/AcidTest.php
+++ b/tests/AcidTest.php
@@ -1,0 +1,44 @@
+<?php
+
+beforeEach(function () {
+    $this->brain = new HelgeSverre\Brain\Brain();
+});
+
+it('It can generate text', function () {
+
+    expect($this->brain->fast()->text('Say hello'))->toBeString();
+});
+
+it('It can give me json', function () {
+    $result = $this->brain->fast()->json('generate details for a fictional person with a name, job_title and age, output as JSON');
+    expect($result)->toBeArray()
+        ->and($result)->toHaveKeys(['name', 'job_title', 'age']);
+});
+
+it('It can give me json list', function () {
+    $result = $this->brain->fast()->list('list 3 fruits');
+
+    expect($result)->toBeArray()
+        ->and($result)->toHaveCount(3);
+});
+
+it('It can classify something', function () {
+    $result = $this->brain->fast()->classify('banana', ['fruit', 'car', 'animal']);
+
+    expect($result)->toBeString()
+        ->and($result)->toEqual('fruit');
+});
+
+it('It can classify something with enum', function () {
+
+    enum Category: string
+    {
+        case fruit = 'fruit';
+        case animal = 'animal';
+        case car = 'car';
+    }
+
+    $result = $this->brain->fast()->classify('banana', Category::class);
+
+    expect($result)->toEqual(Category::fruit);
+});

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('can test', fn () => expect(true)->toBeTrue());
+
+it('will not use debugging functions')
+    ->expect(['dd', 'dump', 'ray'])
+    ->each->not->toBeUsed();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace HelgeSverre\Brain\Tests;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace HelgeSverre\Brain\Tests;
+
+use Dotenv\Dotenv;
+use HelgeSverre\Brain\ServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+            \OpenAI\Laravel\ServiceProvider::class,
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        // Load .env.test into the environment.
+        if (file_exists(dirname(__DIR__).'/.env')) {
+            (Dotenv::createImmutable(dirname(__DIR__), '.env'))->load();
+        }
+
+        config()->set('openai.api_key', env('OPENAI_API_KEY'));
+    }
+}


### PR DESCRIPTION
Added a new function `classify` in the `Brain.php` class to encompass input string classification into an array or a 'StringBackedEnum' type. The method throws an 'InvalidArgumentException' for invalid class type, communicates with `OpenAI` chat to get the classification, and returns it.